### PR TITLE
Correct the spelling of CocoaPods in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # HMImagePicker
 [![Build Status](https://travis-ci.org/itheima-developer/HMImagePicker.svg?branch=master)](https://travis-ci.org/itheima-developer/HMImagePicker)
-[![Cocoapods Compatible](https://img.shields.io/cocoapods/v/HMImagePicker.svg)](https://img.shields.io/cocoapods/v/HMImagePicker.svg)
+[![CocoaPods Compatible](https://img.shields.io/cocoapods/v/HMImagePicker.svg)](https://img.shields.io/cocoapods/v/HMImagePicker.svg)
 [![Platform](https://img.shields.io/cocoapods/p/HMImagePicker.svg?style=flat)](http://cocoadocs.org/docsets/HMImagePicker)
 
 轻量级图像选择框架


### PR DESCRIPTION
This pull requests corrects the spelling of **CocoaPods** 🤓
https://github.com/CocoaPods/shared_resources/tree/master/media

<blockquote class="twitter-tweet" data-lang="en"><p lang="en" dir="ltr">One day I’ll make a bot that looks through the READMEs of all Pods, looks to see if it uses “Cocoapods” and PRs “CocoaPods” :D</p>&mdash; Ørta (@orta) <a href="https://twitter.com/orta/status/697374357975388160">February 10, 2016</a></blockquote>

<script async src="//platform.twitter.com/widgets.js" charset="utf-8"></script>


Created with [`cocoapods-readme`](https://github.com/dkhamsing/cocoapods-readme).  
